### PR TITLE
Fix bug in TimeParser H:MM format

### DIFF
--- a/lib/lita/timing/time_parser.rb
+++ b/lib/lita/timing/time_parser.rb
@@ -22,7 +22,7 @@ module Lita
       end
 
       def self.extract_hours_and_minutes(string)
-        _, hours, minutes = *string.match(/\A(\d\d):(\d\d)\Z/)
+        _, hours, minutes = *string.match(/\A(\d{1,2}):(\d{2})\Z/)
         if hours.nil? || minutes.nil?
           raise ArgumentError, "time should be HH:MM"
         end

--- a/spec/time_parser_spec.rb
+++ b/spec/time_parser_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Lita::Timing::TimeParser do
         expect(result).to eq([23,59])
       end
     end
+    context "with H:MM format" do
+      let(:input) { "1:23" }
+
+      it "returns correct values" do
+        expect(result).to eq([1,23])
+      end
+    end
     context "with invalid string" do
       let(:input) { "Foo" }
 


### PR DESCRIPTION
There was an issue in the TimeParser regex that prevented it from
parsing time strings in H:MM format.
